### PR TITLE
Improve session hash logic

### DIFF
--- a/src/Entities/Session.php
+++ b/src/Entities/Session.php
@@ -115,15 +115,15 @@ class Session
     public function hash()
     {
         $values = [
-            $this->moduleName,
-            $this->type,
-            $this->day,
-            $this->start,
-            $this->end,
+            'module' => $this->moduleName,
+            'type' => $this->type,
+            'day' => $this->day,
+            'start' => $this->start,
+            'end' => $this->end,
         ];
 
         // Potential for collissions - consider serialising as JSON before hashing
-        return md5(implode('', $values));
+        return md5(json_encode($values));
     }
 
     /**

--- a/src/Entities/Session.php
+++ b/src/Entities/Session.php
@@ -122,7 +122,6 @@ class Session
             'end' => $this->end,
         ];
 
-        // Potential for collissions - consider serialising as JSON before hashing
         return md5(json_encode($values));
     }
 

--- a/tests/ParserSessionsTest.php
+++ b/tests/ParserSessionsTest.php
@@ -45,7 +45,7 @@ final class ParserSessionsTest extends TestCase
                     'C016',
                     'C015'
                 ],
-                'hash' => '2b0801d69d67b7bbc4dbe71d881d228d',
+                'hash' => '754be31034bb54be6d936af158e6bfa2',
                 'is_valid' => true,
             ],
             // This session is invalid
@@ -70,7 +70,7 @@ final class ParserSessionsTest extends TestCase
                     'MK010',
                     'MK027',
                 ],
-                'hash' => 'a3433d3e092a859744f9fd497b4aa183',
+                'hash' => 'ae6f58fb88d75ab1ce9e95f42f8cdd6d',
                 'is_valid' => false,
             ],
         ];


### PR DESCRIPTION
The current method - concat data as a string - can cause collisions, instead serialize to JSON then hash. This change will invalidate the hashes of all sessions stored locally by client applications, so this PR will be merged outside of term time to lessen the impact to users.